### PR TITLE
Finetune the Policy by making the 3 default checks explicit in the API

### DIFF
--- a/api/src/main/java/jakarta/security/jacc/Policy.java
+++ b/api/src/main/java/jakarta/security/jacc/Policy.java
@@ -52,7 +52,53 @@ public interface Policy {
      * @param subject holder of the (obscured) caller principal
      * @return true if the caller principal has the requested permission, false otherwise
      */
-    boolean implies(Permission permissionToBeChecked, Subject subject);
+    default boolean implies(Permission permissionToBeChecked, Subject subject) {
+        if (isExcluded(permissionToBeChecked)) {
+            return false;
+        }
+
+        if (isUnchecked(permissionToBeChecked)) {
+            return true;
+        }
+
+        return impliesByRole(permissionToBeChecked, subject);
+    }
+
+    /**
+     * This method checks whether the permission represented by the @{permissionToBeChecked} parameter is
+     * excluded by this policy. Excluded means the permission is not granted to any caller.
+     *
+     * @param permissionToBeChecked the permission this policy is going to check
+     * @return true if the requested permission is excluded, false otherwise
+     */
+    default boolean isExcluded(Permission permissionToBeChecked) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * This method checks whether the permission represented by the @{permissionToBeChecked} parameter is
+     * unchecked by this policy. Unchecked means the permission is granted to any caller, either authenticated
+     * or not.
+     *
+     * @param permissionToBeChecked the permission this policy is going to check
+     * @return true if the requested permission is unchecked, false otherwise
+     */
+    default boolean isUnchecked(Permission permissionToBeChecked) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * This method checks whether the permission represented by the @{permissionToBeChecked} parameter is granted to
+     * the caller principal within the @{subject} parameter based on one or more roles associated with that
+     * caller principal.
+     *
+     * @param permissionToBeChecked the permission this policy is going to check
+     * @param subject holder of the (obscured) caller principal
+     * @return true if the caller principal has the requested permission, false otherwise
+     */
+    default boolean impliesByRole(Permission permissionToBeChecked, Subject subject) {
+        throw new UnsupportedOperationException();
+    }
 
     /**
      * Returns a collection of at least all declared permissions associated with the caller principal

--- a/tck/app-policy3/pom.xml
+++ b/tck/app-policy3/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024 Contributors to the Eclipse Foundation.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+        <groupId>org.eclipse.ee4j.authorization.tck</groupId>
+        <artifactId>jakarta-authorization-tck</artifactId>
+        <version>4.0.0-SNAPSHOT</version>
+    </parent>
+
+	<artifactId>app-mem-policy3</artifactId>
+	<packaging>war</packaging>
+	
+	<description>
+        Access a Servlet, and check from within that Servlet whether the
+        permission checks from the Policy match with the expectations for that request.
+    </description>
+
+	<properties>
+        <failOnMissingWebXml>false</failOnMissingWebXml>
+    </properties>
+
+	<dependencies>
+        <dependency>
+            <groupId>org.eclipse.ee4j.authorization.tck</groupId>
+            <artifactId>common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+	<build>
+        <finalName>app-mem-policy3</finalName>
+	</build>
+</project>

--- a/tck/app-policy3/src/main/java/ee/jakarta/tck/authorization/test/ProtectedServlet.java
+++ b/tck/app-policy3/src/main/java/ee/jakarta/tck/authorization/test/ProtectedServlet.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.authorization.test;
+
+import static jakarta.security.jacc.PolicyContext.SUBJECT;
+
+import jakarta.annotation.security.DeclareRoles;
+import jakarta.security.jacc.Policy;
+import jakarta.security.jacc.PolicyContext;
+import jakarta.security.jacc.PolicyFactory;
+import jakarta.security.jacc.WebResourcePermission;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.HttpConstraint;
+import jakarta.servlet.annotation.ServletSecurity;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.security.Permission;
+import javax.security.auth.Subject;
+
+/**
+ * Protected Servlet that prints out the response from the default policy for the current request.
+ *
+ * <p>
+ * The role "foo" is required to access this Servlet. "bar" and "foo" are roles assigned by the
+ * native identity store
+ *
+ */
+@WebServlet("/protectedServlet/*")
+@DeclareRoles({"bar"})
+@ServletSecurity(@HttpConstraint(rolesAllowed = "foo"))
+public class ProtectedServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        response.getWriter().write("This is a servlet \n");
+
+        Policy policy = PolicyFactory.getPolicyFactory().getPolicy();
+
+        // Check permissions for the current request
+        Permission requestPermission = new WebResourcePermission(request);
+        Subject subject = PolicyContext.get(SUBJECT);
+
+        response.getWriter().write("Current request is unchecked: " + policy.isUnchecked(requestPermission) + "\n");
+        response.getWriter().write("Current request is excluded: " + policy.isExcluded(requestPermission) + "\n");
+        response.getWriter().write("Current request is by role: " + policy.impliesByRole(requestPermission, subject) + "\n");
+    }
+
+}

--- a/tck/app-policy3/src/main/webapp/WEB-INF/beans.xml
+++ b/tck/app-policy3/src/main/webapp/WEB-INF/beans.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024 Contributors to Eclipse Foundation.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       bean-discovery-mode="all" version="4.0">
+</beans>

--- a/tck/app-policy3/src/main/webapp/WEB-INF/web.xml
+++ b/tck/app-policy3/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
+         version="6.0">
+    
+    <login-config>
+        <auth-method>BASIC</auth-method>
+        <realm-name>file</realm-name>
+    </login-config>
+</web-app>

--- a/tck/app-policy3/src/test/java/ee/jakarta/tck/authorization/test/AppPolicy3IT.java
+++ b/tck/app-policy3/src/test/java/ee/jakarta/tck/authorization/test/AppPolicy3IT.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.authorization.test;
+
+import static ee.jakarta.tck.authorization.util.ShrinkWrap.mavenWar;
+import static org.junit.Assert.assertTrue;
+
+import com.gargoylesoftware.htmlunit.DefaultCredentialsProvider;
+import ee.jakarta.tck.authorization.util.ArquillianBase;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class AppPolicy3IT extends ArquillianBase {
+
+    @Deployment(testable = false)
+    public static Archive<?> createDeployment() {
+        return mavenWar();
+    }
+
+    /**
+     * Access a protected Servlet, and check from within that Servlet whether the
+     * permission checks from the Policy match with the expectations for that request.
+     */
+    @Test
+    public void testAuthenticated() {
+        DefaultCredentialsProvider credentialsProvider = new DefaultCredentialsProvider();
+        credentialsProvider.addCredentials("reza", "secret1");
+
+        getWebClient().setCredentialsProvider(credentialsProvider);
+
+        String response = readFromServer("/protectedServlet");
+
+        assertTrue(
+            "Should have not have had unchecked access, but had.\n" +
+            response,
+            response.contains("Current request is unchecked: false"));
+
+        assertTrue(
+                "Should have not be excluded from access, but was.\n" +
+                response,
+                response.contains("Current request is excluded: false"));
+
+        assertTrue(
+                "Should have had access by role, but had not.\n" +
+                response,
+                response.contains("Current request is by role: true"));
+    }
+
+}

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -53,6 +53,7 @@
         <!-- Setting a Jakarta Authorization policy -->
         <module>app-policy</module>
         <module>app-policy2</module>
+        <module>app-policy3</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
This keeps the umbrella implies check, but makes it possible to either wrap or explicitly invoke the individual checks as well.