### PR TITLE
Add TCK test installing a tracing Policy.

### DIFF
--- a/tck/app-custom-trace-policy/pom.xml
+++ b/tck/app-custom-trace-policy/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024 Contributors to Eclipse Foundation.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+        <groupId>org.eclipse.ee4j.authorization.tck</groupId>
+        <artifactId>jakarta-authorization-tck</artifactId>
+        <version>4.0.0-SNAPSHOT</version>
+    </parent>
+
+	<artifactId>app-custom-trace-policy</artifactId>
+	<packaging>war</packaging>
+	
+	<description>
+        This module installs a policy thats test several aspects of the Policy; 
+        whether it's called at all, and if certain context objects are available to it.
+    </description>
+
+	<properties>
+        <failOnMissingWebXml>false</failOnMissingWebXml>
+    </properties>
+
+	<dependencies>
+        <dependency>
+            <groupId>org.eclipse.ee4j.authorization.tck</groupId>
+            <artifactId>common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+	<build>
+        <finalName>app-custom-trace-policy</finalName>
+	</build>
+</project>

--- a/tck/app-custom-trace-policy/pom.xml
+++ b/tck/app-custom-trace-policy/pom.xml
@@ -31,7 +31,7 @@
 	<packaging>war</packaging>
 	
 	<description>
-        This module installs a policy thats test several aspects of the Policy; 
+        This module installs a policy that tests several aspects of the Policy; 
         whether it's called at all, and if certain context objects are available to it.
     </description>
 

--- a/tck/app-custom-trace-policy/src/main/java/ee/jakarta/tck/authorization/test/PolicyRegistrationListener.java
+++ b/tck/app-custom-trace-policy/src/main/java/ee/jakarta/tck/authorization/test/PolicyRegistrationListener.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.authorization.test;
+
+import jakarta.security.jacc.PolicyFactory;
+import jakarta.servlet.ServletContextEvent;
+import jakarta.servlet.ServletContextListener;
+import jakarta.servlet.annotation.WebListener;
+
+/**
+ * ServletContextListener that is used to install a custom authorization policy.
+ *
+ * @author Arjan Tijms
+ *
+ */
+@WebListener
+public class PolicyRegistrationListener implements ServletContextListener {
+
+    @Override
+    public void contextInitialized(ServletContextEvent sce) {
+        PolicyFactory policyFactory = PolicyFactory.getPolicyFactory();
+        policyFactory.setPolicy(new TSPolicy(policyFactory.getPolicy()));
+    }
+
+}

--- a/tck/app-custom-trace-policy/src/main/java/ee/jakarta/tck/authorization/test/TSPolicy.java
+++ b/tck/app-custom-trace-policy/src/main/java/ee/jakarta/tck/authorization/test/TSPolicy.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.authorization.test;
+
+import static java.util.logging.Level.FINER;
+import static java.util.logging.Level.INFO;
+import static java.util.logging.Level.SEVERE;
+
+import ee.jakarta.tck.authorization.util.logging.server.TSLogger;
+import jakarta.security.jacc.Policy;
+import jakarta.security.jacc.PolicyConfiguration;
+import jakarta.security.jacc.PolicyConfigurationFactory;
+import jakarta.security.jacc.PolicyContext;
+import jakarta.security.jacc.WebResourcePermission;
+import jakarta.servlet.http.HttpServletRequest;
+import java.security.Permission;
+import java.security.PermissionCollection;
+import javax.security.auth.Subject;
+
+/**
+ * This is a delegating Policy Implementation class which delegates the permission evaluation to vendor's policy
+ * implementation.
+ *
+ * @author Raja Perumal 08/14/02
+ *
+ */
+public final class TSPolicy implements Policy {
+
+    public static TSLogger logger = TSLogger.getTSLogger();
+
+    private Policy policy;
+
+    public TSPolicy(Policy policy) {
+        this.policy = policy;
+    }
+
+    /**
+     * Evaluates the global policy for the permissions granted to the ProtectionDomain and tests whether the permission is
+     * granted.
+     *
+     * @param permission the Permission object to be tested for implication.
+     * @param subject the Subject to test
+     *
+     * @return true if "permission" is a proper subset of a permission granted to this Subject.
+     * @since 1.4
+     */
+    @Override
+    public boolean implies(Permission permission, Subject subject) {
+        if ((permission instanceof WebResourcePermission) && (permission.getName().equals("/secured.jsp"))) {
+            logger.log(INFO, "Calling policyContextSubject()");
+            policyContextSubject();
+
+            logger.log(INFO, "Calling policyContextHttpServletRequest()");
+            policyContextHttpServletRequest();
+        }
+
+        // If there is a PolicyContext.getContextID, verify that getPolicyConfiguration() methods work
+        String contextId = PolicyContext.getContextID();
+        if (contextId != null) {
+            try {
+                PolicyConfigurationFactory policyConfigurationFactory = PolicyConfigurationFactory.getPolicyConfigurationFactory();
+
+                // Should be non-null PolicyConfiguration
+                PolicyConfiguration policyConfiguration = policyConfigurationFactory.getPolicyConfiguration();
+                if (policyConfiguration != null) {
+                    logger.log(INFO, "PolicyConfigurationFactory.getPolicyConfiguration() : PASSED");
+                } else {
+                    logger.log(INFO, "PolicyConfigurationFactory.getPolicyConfiguration() : FAILED");
+                }
+
+                // Should be non-null PolicyConfiguration and match no-arg getPolicyConfiguration()
+                PolicyConfiguration policyConfiguration2 = policyConfigurationFactory.getPolicyConfiguration(contextId);
+                if (policyConfiguration2 == null || !policyConfiguration.equals(policyConfiguration2)) {
+                    logger.log(INFO, "PolicyConfigurationFactory.getPolicyConfiguration(String) : FAILED");
+                } else {
+                    logger.log(INFO, "PolicyConfigurationFactory.getPolicyConfiguration(String) : PASSED");
+                }
+
+            } catch (Exception e) {
+                logger.log(INFO, "PolicyConfigurationFactory.getPolicyConfiguration() : FAILED");
+            }
+        }
+
+        return policy.implies(permission, subject);
+    }
+
+    /**
+     * Evaluates the global policy and returns a PermissionCollection object specifying the set of permissions allowed given
+     * the characteristics of the protection domain.
+     *
+     * @param subject the Subject associated with the caller.
+     *
+     * @return the set of permissions allowed for the <i>subject</i> according to the policy. The returned set of permissions
+     * must be a new mutable instance and it must support heterogeneous Permission types.
+     *
+     * @since 1.4
+     */
+    @Override
+    public PermissionCollection getPermissionCollection(Subject subject) {
+        if (logger.isLoggable(FINER)) {
+            logger.entering("TSPolicy", "getPermissions");
+        }
+
+        // Print permission collection as logger info ?
+        return policy.getPermissionCollection(subject);
+    }
+
+    /**
+     * Refreshes/reloads the policy configuration. The behavior of this method depends on the implementation. For example,
+     * calling <code>refresh</code> on a file-based policy will cause the file to be re-read.
+     *
+     */
+    @Override
+    public void refresh() {
+        policy.refresh();
+        if (logger != null) {
+            logger.log(INFO, "TSPolicy.refresh() invoked");
+        }
+    }
+
+    /**
+     * testName: policyContextHttpServletRequest
+     *
+     * @assertion_ids: JACC:SPEC:99; JACC:JAVADOC:30
+     *
+     * @test_Strategy: 1) call PolicyContext.getContext("jakarta.servlet.http.HttpServletRequest") 2) verify the return
+     * value is an instance of HttpServletRequest
+     *
+     */
+    private void policyContextHttpServletRequest() {
+        try {
+            // Get HttpServletRequest object
+            HttpServletRequest ctx = PolicyContext.getContext("jakarta.servlet.http.HttpServletRequest");
+            logger.log(INFO, "PolicyContext.getContext() " + "test passed for" + "jakarta.servlet.http.HttpServletRequest " + ctx.getContextPath());
+            logger.log(INFO, "PolicyContextHttpServletRequest: PASSED");
+        } catch (ClassCastException e) {
+            logger.log(INFO,"PolicyContext.getContext()" + "returned incorrect value for key " + "jakarta.servlet.http.HttpServletRequest");
+            logger.log(SEVERE, "PolicyContextHttpServletRequest: FAILED");
+        } catch (Exception e) {
+            logger.log(SEVERE, "PolicyContextHttpServletRequest: FAILED");
+        }
+    }
+
+    /**
+     * testName: policyContextSubject
+     *
+     * @assertion_ids: JACC:SPEC:97; JACC:JAVADOC:30
+     *
+     * @test_Strategy: 1) call PolicyContext.getContext("javax.security.auth.Subject.container) 2) verify the return value
+     * is an instance of javax.security.auth.Subject
+     *
+     */
+    private void policyContextSubject() {
+        try {
+            // Get Subject
+            Subject subject = PolicyContext.getContext("javax.security.auth.Subject.container");
+            logger.log(INFO, "PolicyContext.getContext() " + "test passed for" + "javax.security.auth.Subject.container " + subject.toString());
+            logger.log(INFO, "PolicyContextSubject: PASSED");
+        } catch (ClassCastException e) {
+            logger.log(INFO, "PolicyContext.getContext()" + "returned incorrect value for key " + "javax.security.auth.Subject.container");
+            logger.log(INFO, "PolicyContextSubject: FAILED");
+        } catch (Exception e) {
+            logger.log(SEVERE, "PolicyContextSubject: FAILED");
+        }
+    }
+
+}

--- a/tck/app-custom-trace-policy/src/main/webapp/WEB-INF/beans.xml
+++ b/tck/app-custom-trace-policy/src/main/webapp/WEB-INF/beans.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024 Contributors to Eclipse Foundation.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/app-custom-trace-policy/src/main/webapp/WEB-INF/web.xml
+++ b/tck/app-custom-trace-policy/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024 Contributors to Eclipse Foundation.
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
+         version="6.0">
+    <display-name>jacc_web_toolsContracts</display-name>
+    
+    
+    <!-- By role: authenticated caller in specified role can access  -->
+    <servlet>
+        <display-name>secured</display-name>
+        <servlet-name>secured</servlet-name>
+        <jsp-file>/secured.jsp</jsp-file>
+        <load-on-startup>0</load-on-startup>
+        <security-role-ref>
+            <role-name>ADM</role-name>
+            <role-link>Administrator</role-link>
+        </security-role-ref>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>secured</servlet-name>
+        <url-pattern>/secured.jsp</url-pattern>
+    </servlet-mapping>
+    <security-constraint>
+        <web-resource-collection>
+            <web-resource-name>MySecureBit3</web-resource-name>
+            <url-pattern>/secured.jsp</url-pattern>
+            <http-method>POST</http-method>
+            <http-method>GET</http-method>
+        </web-resource-collection>
+        <auth-constraint>
+            <role-name>Administrator</role-name>
+        </auth-constraint>
+        <user-data-constraint>
+            <transport-guarantee>NONE</transport-guarantee>
+        </user-data-constraint>
+    </security-constraint>
+    
+    
+    <login-config>
+        <auth-method>BASIC</auth-method>
+        <realm-name>default</realm-name>
+    </login-config>
+    
+    <security-role>
+        <role-name>Administrator</role-name>
+    </security-role>
+    <security-role>
+        <role-name>Manager</role-name>
+    </security-role>
+    <security-role>
+        <role-name>Employee</role-name>
+    </security-role>
+</web-app>

--- a/tck/app-custom-trace-policy/src/main/webapp/secured.jsp
+++ b/tck/app-custom-trace-policy/src/main/webapp/secured.jsp
@@ -1,0 +1,48 @@
+<%--
+
+    Copyright (c) 2006, 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+--%>
+
+<!--
+ @(#)secured.jsp	1.3 06/02/19  
+-->
+
+<%@ page language="java" %>
+ 
+<html>
+<head><title>JSP with Security Constraint</title></head>
+<body>
+<h2>JSP with Security Constraint</h2>
+
+<% 
+
+out.println("The user principal is: " + request.getUserPrincipal().getName() + "<BR>");
+out.println("getRemoteUser(): " + request.getRemoteUser() + "<BR>" );
+
+// Surround these with !'s so they are easier to search for.
+// (i.e. we can search for !true! or !false!)
+out.println("isUserInRole(\"ADM\"): !" + request.isUserInRole("ADM") + "!<BR>");
+out.println("isUserInRole(\"MGR\"): !" + request.isUserInRole("MGR") + "!<BR>");
+out.println("isUserInRole(\"VP\"): !" + request.isUserInRole("VP") + "!<BR>");
+out.println("isUserInRole(\"EMP\"): !" + request.isUserInRole("EMP") + "!<BR>");
+out.println("isUserInRole(\"Administrator\"): !" + request.isUserInRole("Administrator") + "!<BR>");
+
+%>
+
+</body>
+</html>
+
+

--- a/tck/app-custom-trace-policy/src/test/java/ee/jakarta/tck/authorization/test/AppCustomTracePolicyIT.java
+++ b/tck/app-custom-trace-policy/src/test/java/ee/jakarta/tck/authorization/test/AppCustomTracePolicyIT.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2024 Contributors to Eclipse Foundation.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.authorization.test;
+
+import static ee.jakarta.tck.authorization.util.ShrinkWrap.mavenWar;
+import static org.junit.Assert.assertTrue;
+
+import ee.jakarta.tck.authorization.util.ArquillianBase;
+import ee.jakarta.tck.authorization.util.logging.client.LogFileProcessor;
+import java.util.logging.Logger;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class AppCustomTracePolicyIT extends ArquillianBase {
+
+    Logger logger = Logger.getLogger(AppCustomTracePolicyIT.class.getName());
+
+    @Deployment(testable = false)
+    public static Archive<?> createDeployment() {
+        return mavenWar();
+    }
+
+    /**
+     * @testName: GetPolicyConfiguration
+     *
+     * @assertion_ids: JACC:SPEC:26; JACC:JAVADOC:28; JACC:JAVADOC:29
+     *
+     * @test_Strategy: 1. Register TS provider with the AppServer.
+     *
+     *                 2. Read the server side log to verify the Policy is called and
+     *                 instantiated in the server.
+     *
+     *                 3. Make sure that from within the Policy, we are able to call
+     *                 the different variants of
+     *                 PolicyConfigurationFactory.getPolicyConfiguration
+     *
+     *                 Description The getPolicyConfiguration method of the
+     *                 factory must be used to find or instantiate
+     *                 PolicyConfiguration objects corresponding to the
+     *                 application or modules being deployed.
+     *
+     */
+    @Test
+    public void GetPolicyConfiguration() {
+      LogFileProcessor logProcessor = new LogFileProcessor("appId", "toolsContracts");
+
+      // Verify whether the log contains required messages.
+      assertTrue(
+          "GetPolicyConfiguration failed : " + "getPolicyconfiguration() failed",
+          logProcessor.verifyLogContains("PolicyConfigurationFactory.getPolicyConfiguration() : PASSED"));
+
+      assertTrue(
+          "GetPolicyConfiguration failed : " + "getPolicyconfiguration(String) failed",
+          logProcessor.verifyLogContains("PolicyConfigurationFactory.getPolicyConfiguration(String) : PASSED"));
+    }
+
+
+    /**
+     * @testName: PolicyRefresh
+     *
+     * @assertion_ids: JACC:SPEC:54; JACC:SPEC:5; JACC:SPEC:23
+     *
+     * @test_Strategy: 1. Register TS provider with the AppServer. (See User guide
+     *                 for Registering TS Provider with your AppServer ).
+     *
+     *                 2. Read the server side log and
+     *                 verify that TSPolicy.refresh() method is called
+     *
+     *                 (Note: This assertion implicitly tests JACC:SPEC:5,
+     *                 JACC:SPEC:23 i.e loading provider specified interfaces by
+     *                 the containers)
+     *
+     */
+    @Test
+    public void PolicyRefresh() {
+      LogFileProcessor logProcessor = new LogFileProcessor("appId", "toolsContracts");
+
+      // verify the log contains TSPolicy.refresh().
+      assertTrue(
+          "PolicyRefresh() failed",
+          logProcessor.verifyLogContains("TSPolicy.refresh() invoked"));
+    }
+
+    /**
+     * @testName: Policy
+     *
+     * @assertion_ids: JACC:SPEC:53; JACC:SPEC:56; JACC:SPEC:67; JACC:SPEC:68;
+     *                 JACC:SPEC:105; JACC:SPEC:14; JACC:SPEC:22
+     *
+     * @test_Strategy: 1. Register TS provider with the AppServer. (See User guide
+     *                 for Registering TS Provider with your AppServer ).
+     *
+     *                 2. Read the server side log, and verify the server side log
+     *                 contains the following string "TSPolicy.refresh() invoked"
+     *
+     *                 3. The occurrence of the above string indicates the server
+     *                 used used the custom policy
+     */
+    @Test
+    public void Policy() {
+        LogFileProcessor logProcessor = new LogFileProcessor("appId", "toolsContracts");
+
+        // verify the log contains TSPolicy.refresh().
+        assertTrue(
+            "TestName: Policy failed : " + "Policy replacement API not used",
+            logProcessor.verifyLogContains("TSPolicy.refresh() invoked"));
+    }
+
+    /**
+     * testName: policyContextHttpServletRequest
+     *
+     * @assertion_ids: JACC:SPEC:99; JACC:JAVADOC:30
+     *
+     * @test_Strategy:
+     *           1) From within a Policy, call PolicyContext.getContext("jakarta.servlet.http.HttpServletRequest")
+     *           2) verify the return value is an instance of HttpServletRequest
+     *           3) This makes sure a Policy has access to the HttpServletRequest
+     *
+     */
+    @Test
+    public void PolicyContextHttpServletRequest() {
+        assertTrue(
+            readFromServerWithCredentials("/secured.jsp", "javajoe", "javajoe").contains("javajoe"));
+
+        LogFileProcessor logProcessor = new LogFileProcessor("appId", "toolsContracts");
+
+        assertTrue(
+            "TestName: Policy failed : " + "HttpServletRequest not available",
+            logProcessor.verifyLogContains("PolicyContextHttpServletRequest: PASSED"));
+    }
+
+
+    /**
+     * testName: policyContextSubject
+     *
+     * @assertion_ids: JACC:SPEC:97; JACC:JAVADOC:30
+     *
+     * @test_Strategy:
+     *          1) From within a Policy, call PolicyContext.getContext("javax.security.auth.Subject.container)
+     *          2) verify the return value is an instance of javax.security.auth.Subject
+     *          3) This makes sure a Policy has access to the Subject
+     *
+     */
+    @Test
+    public void PolicyContextSubject() {
+        assertTrue(
+            readFromServerWithCredentials("/secured.jsp", "javajoe", "javajoe").contains("javajoe"));
+
+        LogFileProcessor logProcessor = new LogFileProcessor("appId", "toolsContracts");
+
+        assertTrue(
+            "TestName: Policy failed : " + "Subject not available",
+            logProcessor.verifyLogContains("PolicyContextSubject: PASSED"));
+
+    }
+
+
+}

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -58,6 +58,7 @@
         <module>app-custom-policy</module>
         <module>app-custom-policy2</module>
         
+        <module>app-custom-trace-policy</module>
         <module>app-custom-trace-policyconfiguration</module>
         <module>app-custom-trace-policyconfigurationfactory</module>
         


### PR DESCRIPTION
This policy test several aspects of the Policy, whether it's called at all, and if certain context objects are available to it.

This ports over a few tests from the old TCK, and enabled some that were dormant.