### PR TITLE
Porting over EJB tests from old TCK

### DIFF
--- a/tck/app-ejb-constraints/pom.xml
+++ b/tck/app-ejb-constraints/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024 Contributors to Eclipse Foundation.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+        <groupId>org.eclipse.ee4j.authorization.tck</groupId>
+        <artifactId>jakarta-authorization-tck</artifactId>
+        <version>4.0.0-SNAPSHOT</version>
+    </parent>
+
+	<artifactId>app-ejb-constraints</artifactId>
+	<packaging>war</packaging>
+
+    <description>
+        This test module uses plain Servlet and Enterprise Beans code and does
+        not use anything Jakarta Authorization specific. It is the responsibility of
+        the one performing the test to make sure the product under test indeed uses
+        Jakarta Authorization internally.
+        
+        Products that don't support Jakarta Authorization, but do provide a
+        compliant Servlet and specificatlly Jakarta Enterprise Beans implementation should
+        be able to pass these tests as well.
+    </description>
+
+	<properties>
+        <failOnMissingWebXml>false</failOnMissingWebXml>
+    </properties>
+
+	<dependencies>
+        <dependency>
+            <groupId>org.eclipse.ee4j.authorization.tck</groupId>
+            <artifactId>common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.ejb</groupId>
+            <artifactId>jakarta.ejb-api</artifactId>
+            <version>4.0.1</version>
+        </dependency>
+    </dependencies>
+
+	<build>
+        <finalName>app-ejb-constraints</finalName>
+	</build>
+</project>

--- a/tck/app-ejb-constraints/src/main/java/ee/jakarta/tck/authorization/test/InterMediate.java
+++ b/tck/app-ejb-constraints/src/main/java/ee/jakarta/tck/authorization/test/InterMediate.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024 Contributors to Eclipse Foundation.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.authorization.test;
+
+public interface InterMediate {
+
+    boolean IsCallerB1(String caller);
+    boolean IsCallerB2(String caller);
+    boolean InRole(String role);
+    boolean EjbNotAuthz();
+    boolean EjbIsAuthz();
+    boolean EjbSecRoleRef(String role);
+    boolean uncheckedTest();
+    boolean excludeTest();
+
+}

--- a/tck/app-ejb-constraints/src/main/java/ee/jakarta/tck/authorization/test/InterMediateBean.java
+++ b/tck/app-ejb-constraints/src/main/java/ee/jakarta/tck/authorization/test/InterMediateBean.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2024 Contributors to Eclipse Foundation.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.authorization.test;
+
+import static jakarta.ejb.TransactionAttributeType.NEVER;
+import static java.util.logging.Level.INFO;
+
+import jakarta.annotation.Resource;
+import jakarta.annotation.security.DeclareRoles;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.annotation.security.RunAs;
+import jakarta.ejb.EJB;
+import jakarta.ejb.EJBAccessException;
+import jakarta.ejb.EJBs;
+import jakarta.ejb.SessionContext;
+import jakarta.ejb.Stateless;
+import jakarta.ejb.TransactionAttribute;
+import jakarta.ejb.TransactionManagement;
+import jakarta.ejb.TransactionManagementType;
+import java.util.logging.Logger;
+
+@EJBs({
+    @EJB(name = "TargetBean", beanName = "TargetBean", beanInterface = Target.class) })
+@TransactionManagement(TransactionManagementType.CONTAINER)
+@DeclareRoles({ "Administrator", "Employee", "Manager" })
+@RolesAllowed({ "Administrator", "Employee", "Manager" })
+@RunAs("Manager")
+@Stateless(name = "InterMediateBean")
+public class InterMediateBean implements InterMediate {
+
+    private Logger logger = Logger.getLogger(InterMediateBean.class.getName());
+
+    // Lookup TargetBean and save the reference in ejb1
+    @EJB(beanName = "TargetBean")
+    private Target ejb1;
+
+    private SessionContext sessionContext;
+
+    @Resource
+    public void setSessionContext(SessionContext sessionContext) {
+        this.sessionContext = sessionContext;
+    }
+
+    @Override
+    @RolesAllowed({ "Administrator", "Employee", "Manager" })
+    @TransactionAttribute(NEVER)
+    public boolean IsCallerB1(String caller) {
+        String name = sessionContext.getCallerPrincipal().getName();
+        logMsg("IsCallerB1: " + name);
+
+        return !(name.indexOf(caller) < 0);
+    }
+
+    @Override
+    @RolesAllowed({ "Administrator", "Employee", "Manager" })
+    @TransactionAttribute(NEVER)
+    public boolean IsCallerB2(String caller) {
+        try {
+            logMsg("Running IsCallerB2 :" + caller);
+            return ejb1.IsCaller(caller);
+        } catch (Exception e) {
+            logMsg("Caught Unexpected exception e.getMessage()");
+            return false;
+        }
+    }
+
+    @Override
+    @RolesAllowed({ "Administrator", "Employee", "Manager" })
+    @TransactionAttribute(NEVER)
+    public boolean InRole(String role) {
+        try {
+            logMsg("Running InRole : " + role);
+            return ejb1.EjbSecRoleRef(role);
+        } catch (Exception e) {
+            logMsg("Caught Unexpected exception e.getMessage()");
+            return false;
+        }
+    }
+
+    @Override
+    @RolesAllowed({ "Administrator", "Employee", "Manager" })
+    @TransactionAttribute(NEVER)
+    public boolean EjbNotAuthz() {
+        try {
+            ejb1.EjbNotAuthz();
+            logMsg("Method call did not generate an expected jakarta.ejb.EJBAccessException");
+            return false;
+        } catch (EJBAccessException e) {
+            logMsg("Caught jakarta.ejb.EJBAccessException as expected");
+            cleanup(ejb1);
+            return true;
+        } catch (Exception e) {
+            logMsg("Caught Unexpected exception e.getMessage()");
+            cleanup(ejb1);
+            return false;
+        }
+    }
+
+    private void cleanup(Target ejbref) {
+
+    }
+
+    @Override
+    @RolesAllowed({ "Administrator", "Employee", "Manager" })
+    @TransactionAttribute(NEVER)
+    public boolean EjbIsAuthz() {
+        logMsg("In InterMediateBean.EjbIsAuthz method");
+        try {
+            boolean result = ejb1.EjbIsAuthz();
+
+            if (!result) {
+                return false;
+            }
+
+        } catch (Exception e) {
+            logMsg("Caught Unexpected exception e.getMessage()");
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    @RolesAllowed({ "Administrator", "Employee", "Manager" })
+    @TransactionAttribute(NEVER)
+    public boolean EjbSecRoleRef(String role) {
+        logMsg("In InterMediateBean.EjbSecRoleRef method");
+        try {
+            return ejb1.EjbSecRoleRef(role);
+        } catch (Exception e) {
+            logMsg("Caught Unexpected exception e.getMessage()");
+            return false;
+        }
+    }
+
+    @Override
+    @RolesAllowed({ "Administrator", "Employee", "Manager" })
+    @TransactionAttribute(NEVER)
+    public boolean uncheckedTest() {
+        logMsg("In InterMediateBean.uncheckedTest method");
+        try {
+            return ejb1.uncheckedTest();
+        } catch (Exception e) {
+            logMsg("InterMediateBean.unchecktedTest failed with exception: " + e.getMessage());
+            return false;
+        }
+    }
+
+    @Override
+    @RolesAllowed({ "Administrator", "Employee", "Manager" })
+    @TransactionAttribute(NEVER)
+    public boolean excludeTest() {
+        logMsg("In InterMediateBean.excludeTest method");
+
+        try {
+            ejb1.excludeTest();
+            return false;
+        } catch (EJBAccessException ex) {
+            logMsg("InterMediateBean : Got expected EJBAccessException");
+            return true;
+
+        } catch (Exception e) {
+            logMsg("InterMediateBean.excludeTest failed with exception: " + e.getMessage());
+            return false;
+        }
+    }
+
+    @TransactionAttribute(NEVER)
+    public void logMsg(String msg) {
+        logger.log(INFO, msg);
+    }
+
+}

--- a/tck/app-ejb-constraints/src/main/java/ee/jakarta/tck/authorization/test/ProtectedServlet.java
+++ b/tck/app-ejb-constraints/src/main/java/ee/jakarta/tck/authorization/test/ProtectedServlet.java
@@ -1,0 +1,317 @@
+/*
+ * Copyright (c) 2024 Contributors to Eclipse Foundation.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.authorization.test;
+
+import jakarta.ejb.EJB;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.HttpConstraint;
+import jakarta.servlet.annotation.ServletSecurity;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.PrintWriter;
+
+/**
+ * This Servlet runs each of the Enterprise Beans tests.
+ *
+ * <p>
+ * Note that this uses plain Servlet and Enterprise Beans code and does not
+ * use anything Jakarta Authorization specific. It is the responsibility of the
+ * one performing the test to make sure the product under test indeed uses
+ * Jakarta Authorization internally.
+ *
+ * <p>
+ * Products that don't support Jakarta Authorization, but do provide a compliant
+ * Servlet and specificatlly Jakarta Enterprise Beans implementation should be able
+ * to pass these tests as well.
+ *
+ * <p>
+ * All the tests require an initial caller authenticated as "j2ee" with role "Employee".
+ *
+ */
+@WebServlet("/protectedServlet/*")
+@ServletSecurity(@HttpConstraint(rolesAllowed = "Employee"))
+public class ProtectedServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @EJB(beanName = "InterMediateBean")
+    private InterMediate ejbref;
+
+    // Security role references.
+    // Note: To test annotation @DeclareRoles, same role names are used as
+    // role-links. If there is a need to link different role-names for
+    // role-links then old-style deployment descriptor should be used for
+    // adding such role references.
+    private static final String emp_secrole_ref = "Employee";
+    private static final String admin_secrole_ref = "Administrator";
+    private static final String mgr_secrole_ref = "Manager";
+
+    // Principal name corresponding to RunAs.  It's server specific how to exactly set this
+    // for the RunAs role "Manager". The default here uses identity mapping.
+    private String authuser = "Manager";
+    private String username = "j2ee";
+
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+
+        response.getWriter().write("This is a servlet \n");
+
+        switch (request.getParameter("test")) {
+            case "ADM_InRole":
+                ADM_InRole(response.getWriter());
+                break;
+            case "EjbIsAuthz":
+                EjbIsAuthz(response.getWriter());
+                break;
+            case "EjbNotAuthz":
+                EjbNotAuthz(response.getWriter());
+                break;
+            case "EjbSecRoleRef":
+                EjbSecRoleRef(response.getWriter());
+                break;
+            case "excludeTest":
+                excludeTest(response.getWriter());
+                break;
+            case "InterMediateBean_CallerPrincipal":
+                InterMediateBean_CallerPrincipal(response.getWriter());
+                break;
+            case "MGR_InRole":
+                MGR_InRole(response.getWriter());
+                break;
+            case "TargetBean_CallerPrincipal":
+                TargetBean_CallerPrincipal(response.getWriter());
+                break;
+            case "uncheckedTest":
+                uncheckedTest(response.getWriter());
+                break;
+        }
+    }
+
+    /*
+     * @testName: ADM_InRole
+     *
+     * @assertion_ids: EJB:SPEC:61.8; // Add JSR250 assertion for DeclareRoles
+     *
+     * @test_Strategy: 1. Create a stateless session bean "InterMediateBean" with runas identity set to <Manager> 2. Create
+     * another stateless session beans "TargetBean" 3. Invoke InterMediateBean.InRole() with admin_secrole_ref this inturn
+     * invokes TargetBean.IsCaller() with admin_secrole_ref 4. Since InterMediateBean is configured to run as <Manager> the
+     * TargetBean.IsCaller() with admin_secrole_ref must return false.
+     */
+    public void ADM_InRole(PrintWriter writer) {
+        writer.write("Starting ADM_InRole test");
+        try {
+            if (ejbref.InRole(admin_secrole_ref)) {
+                throw new IllegalStateException("ADM_InRole test failed");
+            }
+            writer.write("ADM_InRole test passed");
+        } catch (Exception e) {
+            throw new IllegalStateException("ADM_InRole test failed:", e);
+        }
+    }
+
+    /*
+     * @testName: EjbIsAuthz
+     *
+     * @assertion_ids: EJB:SPEC:827; JACC:SPEC:103; // Add JSR250 Assertion for RolesAllowed
+     *
+     * @test_Strategy: 1. Create a stateless session bean "InterMediateBean" with runas identity set to <Manager> 2. Create
+     * another stateless session bean "TargetBean" with method EjbIsAuthz 3. Protect the method with multiple security roles
+     * including <Manager> 4. Call the InterMediateBean.EjbIsAuthz() as principal <username,password>. Which then invokes
+     * the EjbIsAuthz() on the TargetBean. 5. Since then InterMediateBean uses runas identity, <Manager>, which is one of
+     * security roles set on the method permission, so access to the method EjbIsAuthz should be allowed. 6. Verify call
+     * returns successfully.
+     */
+    public void EjbIsAuthz(PrintWriter writer) {
+        writer.write("Starting EjbIsAuthz test");
+        try {
+            if (!ejbref.EjbIsAuthz()) {
+                throw new IllegalStateException("EjbIsAuthz test failed");
+            }
+            writer.write("EjbIsAuthz test passed");
+        } catch (Exception e) {
+            throw new IllegalStateException("EjbIsAuthz test failed: ", e);
+        }
+    }
+
+    /*
+     * @testName: EjbNotAuthz
+     *
+     * @assertion_ids: EJB:SPEC:811 ; JACC:SPEC:103; // Add JSR250 assertion for RolesAllowed
+     *
+     * @test_Strategy: 1. Create a stateless session bean "InterMediateBean" with runas identity set to <Manager> 2. Create
+     * another stateless session bean "TargetBean" with method EjbNotAuthz 3. Protect the method with security role
+     * <Administrator> 4. Call the bean InterMediateBean.EjbNotAuthz() as principal <username,password>. Which then invokes
+     * the EjbNotAuthz() on the bean TargetBean. 5. Since then InterMediateBean uses runas identity, <Manager>, which does
+     * not share any principals with role <Administrator>. so access to the method EjbNotAuthz shouldnot be allowed. 6.
+     * Verify jakarta.ejb.EJBAccessException is generated.
+     */
+    public void EjbNotAuthz(PrintWriter writer) {
+        writer.write("Starting EjbNotAuthz test");
+        try {
+            if (!ejbref.EjbNotAuthz()) {
+                throw new IllegalStateException("EjbNotAuthz test failed");
+            }
+            writer.write("EjbNotAuthz test passed");
+        } catch (Exception e) {
+            throw new IllegalStateException("EjbNotAuthz test failed:", e);
+        }
+    }
+
+    /*
+     * @testName: EjbSecRoleRef
+     *
+     * @assertion_ids: EJB:SPEC:61.7; EJB:SPEC:81.4; // Add JSR 250 assertion for DeclareRoles
+     *
+     * @test_Strategy:
+     *  1. Create a stateless session bean "InterMediateBean" with runas identity set to <Manager>
+     *  2. Create another stateless session bean "TargetBean" with method EjbSecRoleRef.
+     *  3. Protect the method with security role <Employee>, Link a security role ref - emp_secrole_ref to role <Employee>.
+     *  4. Call InterMediateBean.EjbSecRoleRef() principal <username,password>. Which then invokes EjbSecRoleRef on the bean TargetBean.
+     *  5. Since then InterMediateBean uses runas identity, <Manager>, who's principals also in role <Employee> so access to the method of
+     * bean TargetBean should be allowed.
+     *  6. verify that return value of isCallerInRole(emp_secrole_ref) is true.
+     */
+    public void EjbSecRoleRef(PrintWriter writer) {
+        writer.write("Starting EjbSecRoleRef test");
+        try {
+            if (!ejbref.EjbSecRoleRef(emp_secrole_ref)) {
+                throw new IllegalStateException("EjbSecRoleRef test failed");
+            }
+            writer.write("EjbSecRoleRef test passed");
+        } catch (Exception e) {
+            throw new IllegalStateException("EjbSecRoleRef test failed: ", e);
+        }
+    }
+
+    /*
+     * @testName: excludeTest
+     *
+     * @assertion_ids: EJB:SPEC:808; // Add JSR250 assertion for DenyAll
+     *
+     * @test_Strategy: 1. Create a stateless session bean with runas identity <Manager> 2. Invoke
+     * InterMediateBean.excludeTest(), this in-turn invokes TargetBean.excludeTest(). 3. Put the TargetBean's excludeTest()
+     * method in the exclude-list or DenyAll 4. Verify that jakarta.ejb.EJBAccessException is generated.
+     */
+    public void excludeTest(PrintWriter writer) {
+        writer.write("Starting excludeTest ");
+        try {
+            if (!ejbref.excludeTest()) {
+                writer.write("excludeTest returned false");
+                throw new IllegalStateException("excludeTest failed");
+            }
+            writer.write("excludeTest passed");
+        } catch (Exception e) {
+            throw new IllegalStateException("excludeTest failed:", e);
+        }
+    }
+
+    /*
+     * @testName: InterMediateBean_CallerPrincipal
+     *
+     * @assertion_ids: EJB:SPEC:796; // Add JSR250 assertion for RunAs
+     *
+     * @test_Strategy: 1. Create a stateless session bean InterMediateBean with runas identity set to <Manager> 2. Verify
+     * that InterMediateBean returns the correct getCallerPrincipal() this should not be affected because it is configured
+     * to run as <Manager>
+     */
+    public void InterMediateBean_CallerPrincipal(PrintWriter writer) {
+        writer.write("Starting InterMediateBean_CallerPrincipal test");
+        try {
+            if (!ejbref.IsCallerB1(username)) {
+                throw new IllegalStateException("InterMediateBean_CallerPrincipal test failed");
+            }
+            writer.write("InterMediateBean_CallerPrincipal test passed");
+        } catch (Exception e) {
+            throw new IllegalStateException("InterMediateBean_CallerPrincipal test failed:", e);
+        }
+    }
+
+    /*
+     * @testName: MGR_InRole
+     *
+     * @assertion_ids: EJB:SPEC:827; //Add JSR 250 assertion for DeclareRoles
+     *
+     * @test_Strategy: 1. Create a stateless session bean "InterMediateBean" with runas identity set to <Manager> 2. Create
+     * another stateless session beans "TargetBean" 3. Invoke InterMediateBean.InRole() with mgr_secrole_ref this inturn
+     * invokes TargetBean.IsCaller() with mgr_secrole_ref 4. Since InterMediateBean is configured to run as <Manager> the
+     * TargetBean.IsCaller() with mgr_secrole_ref must return true.
+     */
+    public void MGR_InRole(PrintWriter writer) {
+        writer.write("Starting MGR_InRole");
+        try {
+            if (!ejbref.InRole(mgr_secrole_ref)) {
+                throw new IllegalStateException("MGR_InRole test failed");
+            }
+            writer.write("MGR_InRole test passed");
+        } catch (Exception e) {
+            throw new IllegalStateException("MGR_InRole test failed:", e);
+        }
+    }
+
+    /*
+     * @testName: TargetBean_CallerPrincipal
+     *
+     * @assertion_ids: EJB:SPEC:796; // Add JSR250 assertion for RunAs
+     *
+     * @test_Strategy:
+     *  1. Create a stateless session bean "InterMediateBean" with runas identity set to <Manager>
+     *  2. Create another stateless session bean "TargetBean".
+     *  3. Verify that TargetBean returns the correct getCallerPrincipal() which
+     *     is the principal using runas identity, but not the principal invoked InterMediateBean.
+     */
+    public void TargetBean_CallerPrincipal(PrintWriter writer) {
+        writer.write("Starting TargetBean_CallerPrincipal test");
+        try {
+            if (ejbref.IsCallerB2(username) || !ejbref.IsCallerB2(authuser)) {
+                throw new IllegalStateException("TargetBean_CallerPrincipal test failed");
+            }
+
+            writer.write("TargetBean_CallerPrincipal test passed");
+        } catch (Exception e) {
+            throw new IllegalStateException("TargetBean_CallerPrincipal test failed:", e);
+        }
+    }
+
+    /*
+     * @testName: uncheckedTest
+     *
+     * @assertion_ids: EJB:SPEC:827; note: Add JSR250 assertion for PermitAll
+     *
+     * @test_Strategy: 1. Create a stateless session bean with runas identity <Manager> 2. Invoke
+     * InterMediateBean.uncheckedTest() this in-turn invokes TargetBean.uncheckedTest(). 3. Protect the TargetBean's
+     * uncheckedTest() with method permission "unchecked" or PermitAll 4. Verify that access is allowed.
+     */
+
+    public void uncheckedTest(PrintWriter writer) {
+        writer.write("Starting uncheckedTest ");
+        try {
+            if (!ejbref.uncheckedTest()) {
+                writer.write("uncheckedTest returned false");
+                throw new IllegalStateException("uncheckedTest failed");
+            }
+
+            writer.write("uncheckedTest passed.");
+        } catch (Exception e) {
+            throw new IllegalStateException("uncheckedTest failed", e);
+        }
+    }
+
+}

--- a/tck/app-ejb-constraints/src/main/java/ee/jakarta/tck/authorization/test/Target.java
+++ b/tck/app-ejb-constraints/src/main/java/ee/jakarta/tck/authorization/test/Target.java
@@ -1,0 +1,27 @@
+/*
+ *Copyright (c) 2024 Contributors to Eclipse Foundation.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.authorization.test;
+
+public interface Target {
+
+    boolean IsCaller(String caller);
+    boolean EjbNotAuthz();
+    boolean EjbIsAuthz();
+    boolean EjbSecRoleRef(String role);
+    boolean uncheckedTest();
+    boolean excludeTest();
+}

--- a/tck/app-ejb-constraints/src/main/java/ee/jakarta/tck/authorization/test/TargetBean.java
+++ b/tck/app-ejb-constraints/src/main/java/ee/jakarta/tck/authorization/test/TargetBean.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2024 Contributors to Eclipse Foundation.
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.authorization.test;
+
+import static jakarta.ejb.TransactionAttributeType.REQUIRED;
+
+import jakarta.annotation.Resource;
+import jakarta.annotation.security.DeclareRoles;
+import jakarta.annotation.security.DenyAll;
+import jakarta.annotation.security.PermitAll;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ejb.SessionContext;
+import jakarta.ejb.Stateless;
+import jakarta.ejb.TransactionAttribute;
+
+@DeclareRoles({ "Administrator", "Manager", "Employee" })
+@Stateless(name = "TargetBean")
+public class TargetBean implements Target {
+
+    private SessionContext sessionContext;
+
+    @Resource
+    public void setSessionContext(SessionContext sc) {
+        sessionContext = sc;
+    }
+
+    @Override
+    @TransactionAttribute(REQUIRED)
+    public boolean IsCaller(String caller) {
+        return !(sessionContext.getCallerPrincipal().getName().indexOf(caller) < 0);
+    }
+
+    @Override
+    @RolesAllowed({ "Administrator" })
+    @TransactionAttribute(REQUIRED)
+    public boolean EjbNotAuthz() {
+        return true;
+    }
+
+    @Override
+    @RolesAllowed({ "Administrator", "Manager", "Employee" })
+    @TransactionAttribute(REQUIRED)
+    public boolean EjbIsAuthz() {
+        return true;
+    }
+
+    @Override
+    @RolesAllowed({ "Manager", "Employee" })
+    @TransactionAttribute(REQUIRED)
+    public boolean EjbSecRoleRef(String role) {
+        return sessionContext.isCallerInRole(role);
+    }
+
+    @Override
+    @PermitAll
+    public boolean uncheckedTest() {
+        return true;
+    }
+
+    @Override
+    @DenyAll
+    @TransactionAttribute(REQUIRED)
+    public boolean excludeTest() {
+        return true;
+    }
+
+}

--- a/tck/app-ejb-constraints/src/main/webapp/WEB-INF/beans.xml
+++ b/tck/app-ejb-constraints/src/main/webapp/WEB-INF/beans.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024 Contributors to Eclipse Foundation.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/app-ejb-constraints/src/main/webapp/WEB-INF/web.xml
+++ b/tck/app-ejb-constraints/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
+         version="6.0">
+    
+    <login-config>
+        <auth-method>BASIC</auth-method>
+        <realm-name>file</realm-name>
+    </login-config>
+</web-app>

--- a/tck/app-ejb-constraints/src/test/java/ee/jakarta/tck/authorization/test/AppEJBConstraintsIT.java
+++ b/tck/app-ejb-constraints/src/test/java/ee/jakarta/tck/authorization/test/AppEJBConstraintsIT.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2024 Contributors to Eclipse Foundation.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.authorization.test;
+
+import static ee.jakarta.tck.authorization.util.ShrinkWrap.mavenWar;
+import static org.junit.Assert.assertTrue;
+
+import ee.jakarta.tck.authorization.util.ArquillianBase;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class AppEJBConstraintsIT extends ArquillianBase {
+
+    @Deployment(testable = false)
+    public static Archive<?> createDeployment() {
+        return mavenWar();
+    }
+
+    /*
+     * @testName: ADM_InRole
+     *
+     * @assertion_ids: EJB:SPEC:61.8; // Add JSR250 assertion for DeclareRoles
+     *
+     * @test_Strategy:
+     *  1. Create a stateless session bean "InterMediateBean" with runas identity set to <Manager>
+     *  2. Create another stateless session beans "TargetBean"
+     *  3. Invoke InterMediateBean.InRole() with admin_secrole_ref this inturn
+     *     invokes TargetBean.IsCaller() with admin_secrole_ref
+     *  4. Since InterMediateBean is configured to run as <Manager> the
+     *     TargetBean.IsCaller() with admin_secrole_ref must return false.
+     */
+    @Test
+    public void ADM_InRole() {
+        assertTrue(
+            readFromServerWithCredentials("/protectedServlet?test=ADM_InRole", "j2ee", "j2ee")
+                .contains("ADM_InRole test passed"));
+    }
+
+    /*
+     * @testName: EjbIsAuthz
+     *
+     * @assertion_ids: EJB:SPEC:827; JACC:SPEC:103; // Add JSR250 Assertion for RolesAllowed
+     *
+     * @test_Strategy:
+     *  1. Create a stateless session bean "InterMediateBean" with runas identity set to <Manager>
+     *  2. Create another stateless session bean "TargetBean" with method EjbIsAuthz
+     *  3. Protect the method with multiple security roles including <Manager>
+     *  4. Call the InterMediateBean.EjbIsAuthz() as principal <username,password>. Which then invokes
+     *     the EjbIsAuthz() on the TargetBean.
+     *  5. Since then InterMediateBean uses runas identity, <Manager>, which is one of security roles set
+     *  on the method permission, so access to the method EjbIsAuthz should be allowed.
+     *  6. Verify call returns successfully.
+     */
+    @Test
+    public void EjbIsAuthz() {
+        assertTrue(
+            readFromServerWithCredentials("/protectedServlet?test=EjbIsAuthz", "j2ee", "j2ee")
+                .contains("EjbIsAuthz test passed"));
+    }
+
+    /*
+     * @testName: EjbNotAuthz
+     *
+     * @assertion_ids: EJB:SPEC:811 ; JACC:SPEC:103; // Add JSR250 assertion for RolesAllowed
+     *
+     * @test_Strategy:
+     *  1. Create a stateless session bean "InterMediateBean" with runas identity set to <Manager>
+     *  2. Create another stateless session bean "TargetBean" with method EjbNotAuthz
+     *  3. Protect the method with security role
+     * <Administrator>
+     *  4. Call the bean InterMediateBean.EjbNotAuthz() as principal <username,password>. Which then invokes
+     * the EjbNotAuthz() on the bean TargetBean.
+     *  5. Since then InterMediateBean uses runas identity, <Manager>, which does
+     * not share any principals with role <Administrator>. so access to the method EjbNotAuthz shouldnot be allowed.
+     *  6.Verify jakarta.ejb.EJBAccessException is generated.
+     */
+    @Test
+    public void EjbNotAuthz() {
+        assertTrue(
+            readFromServerWithCredentials("/protectedServlet?test=EjbNotAuthz", "j2ee", "j2ee")
+                .contains("EjbNotAuthz test passed"));
+    }
+
+    /*
+     * @testName: EjbSecRoleRef
+     *
+     * @assertion_ids: EJB:SPEC:61.7; EJB:SPEC:81.4; // Add JSR 250 assertion for DeclareRoles
+     *
+     * @test_Strategy:
+     *  1. Create a stateless session bean "InterMediateBean" with runas identity set to <Manager>
+     *  2. Create another stateless session bean "TargetBean" with method EjbSecRoleRef.
+     *  3. Protect the method with security role <Employee>, Link a security role ref - emp_secrole_ref to role <Employee>.
+     *  4. Call InterMediateBean.EjbSecRoleRef() principal <username,password>. Which then invokes EjbSecRoleRef on the bean TargetBean.
+     *  5. Since then InterMediateBean uses runas identity, <Manager>, who's principals also in role <Employee> so access to the method of
+     * bean TargetBean should be allowed.
+     *  6. verify that return value of isCallerInRole(emp_secrole_ref) is true.
+     */
+    @Test
+    public void EjbSecRoleRef() {
+        assertTrue(
+            readFromServerWithCredentials("/protectedServlet?test=EjbSecRoleRef", "j2ee", "j2ee")
+                .contains("EjbSecRoleRef test passed"));
+    }
+
+    /*
+     * @testName: excludeTest
+     *
+     * @assertion_ids: EJB:SPEC:808; // Add JSR250 assertion for DenyAll
+     *
+     * @test_Strategy:
+     *  1. Create a stateless session bean with runas identity <Manager>
+     *  2. Invoke
+     * InterMediateBean.excludeTest(), this in-turn invokes TargetBean.excludeTest().
+     *  3. Put the TargetBean's excludeTest()
+     * method in the exclude-list or DenyAll
+     *  4. Verify that jakarta.ejb.EJBAccessException is generated.
+     */
+    @Test
+    public void excludeTest() {
+        assertTrue(
+            readFromServerWithCredentials("/protectedServlet?test=excludeTest", "j2ee", "j2ee")
+                .contains("excludeTest passed"));
+    }
+
+    /*
+     * @testName: InterMediateBean_CallerPrincipal
+     *
+     * @assertion_ids: EJB:SPEC:796; // Add JSR250 assertion for RunAs
+     *
+     * @test_Strategy:
+     *  1. Create a stateless session bean InterMediateBean with runas identity set to <Manager>
+     *  2. Verify that InterMediateBean returns the correct getCallerPrincipal() this should not be affected because
+     *  it is configured to run as <Manager>
+     */
+    @Test
+    public void InterMediateBean_CallerPrincipal() {
+        assertTrue(
+            readFromServerWithCredentials("/protectedServlet?test=InterMediateBean_CallerPrincipal", "j2ee", "j2ee")
+                .contains("InterMediateBean_CallerPrincipal test passed"));
+    }
+
+    /*
+     * @testName: MGR_InRole
+     *
+     * @assertion_ids: EJB:SPEC:827; //Add JSR 250 assertion for DeclareRoles
+     *
+     * @test_Strategy:
+     *  1. Create a stateless session bean "InterMediateBean" with runas identity set to <Manager>
+     *  2. Create
+     * another stateless session beans "TargetBean"
+     *  3. Invoke InterMediateBean.InRole() with mgr_secrole_ref this inturn
+     * invokes TargetBean.IsCaller() with mgr_secrole_ref
+     *  4. Since InterMediateBean is configured to run as <Manager> the
+     * TargetBean.IsCaller() with mgr_secrole_ref must return true.
+     */
+    @Test
+    public void MGR_InRole() {
+        assertTrue(
+            readFromServerWithCredentials("/protectedServlet?test=MGR_InRole", "j2ee", "j2ee")
+                .contains("MGR_InRole test passed"));
+    }
+
+    /*
+     * @testName: TargetBean_CallerPrincipal
+     *
+     * @assertion_ids: EJB:SPEC:796; // Add JSR250 assertion for RunAs
+     *
+     * @test_Strategy:
+     *  1. Create a stateless session bean "InterMediateBean" with runas identity set to <Manager>
+     *  2. Create another stateless session bean "TargetBean".
+     *  3. Verify that TargetBean returns the correct getCallerPrincipal() which
+     *     is the principal using runas identity, but not the principal invoked InterMediateBean.
+     */
+    @Test
+    public void TargetBean_CallerPrincipal() {
+        assertTrue(
+            readFromServerWithCredentials("/protectedServlet?test=TargetBean_CallerPrincipal", "j2ee", "j2ee")
+                .contains("CallerPrincipal test passed"));
+    }
+
+    /*
+     * @testName: uncheckedTest
+     *
+     * @assertion_ids: EJB:SPEC:827; note: Add JSR250 assertion for PermitAll
+     *
+     * @test_Strategy:
+     *  1. Create a stateless session bean with runas identity <Manager>
+     *  2. Invoke InterMediateBean.uncheckedTest() this in-turn invokes TargetBean.uncheckedTest().
+     *  3. Protect the TargetBean's uncheckedTest() with method permission "unchecked" or PermitAll
+     *  4. Verify that access is allowed.
+     */
+    @Test
+    public void uncheckedTest() {
+        assertTrue(
+            readFromServerWithCredentials("/protectedServlet?test=uncheckedTest", "j2ee", "j2ee")
+                .contains("uncheckedTest passed"));
+    }
+
+}

--- a/tck/common/src/main/java/ee/jakarta/tck/authorization/util/ShrinkWrap.java
+++ b/tck/common/src/main/java/ee/jakarta/tck/authorization/util/ShrinkWrap.java
@@ -20,7 +20,6 @@ import static java.lang.System.getProperty;
 import static org.jboss.shrinkwrap.api.ShrinkWrap.create;
 
 import java.io.File;
-
 import org.jboss.shrinkwrap.api.importer.ZipImporter;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 

--- a/tck/common/src/main/java/ee/jakarta/tck/authorization/util/logging/client/LogRecordEntry.java
+++ b/tck/common/src/main/java/ee/jakarta/tck/authorization/util/logging/client/LogRecordEntry.java
@@ -17,7 +17,6 @@
 package ee.jakarta.tck.authorization.util.logging.client;
 
 import java.io.Serializable;
-
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -71,6 +71,8 @@
         
         <!-- Testing plain Servlet behaviour without anything Jakarta Authorization specific -->
         <module>app-servlet-constraints</module>
+        <!-- Testing plain EJB behaviour without anything Jakarta Authorization specific -->
+        <module>app-ejb-constraints</module>
     </modules>
 
     <properties>
@@ -359,6 +361,7 @@
                                 <glassfish.postBootCommands>
                                     create-file-user --groups foo:bar --passwordfile ${maven.multiModuleProjectDirectory}/reza.pass reza
                                     create-file-user --groups Administrator:Manager:Employee --passwordfile ${maven.multiModuleProjectDirectory}/javajoe.pass javajoe
+                                    create-file-user --groups Manager:Employee --passwordfile ${maven.multiModuleProjectDirectory}/javajoe.pass Manager
                                     create-file-user --groups Employee --passwordfile ${maven.multiModuleProjectDirectory}/j2ee.pass j2ee
                                 </glassfish.postBootCommands>
                             </systemProperties>


### PR DESCRIPTION
Tests ported from:

```
[INFO]      [exec] [javatest.batch] PASSED........com/sun/ts/tests/jacc/ejb/mr/Client.java#ADM_InRole_from_ejblitesecuredjsp
[INFO]      [exec] [javatest.batch] PASSED........com/sun/ts/tests/jacc/ejb/mr/Client.java#EjbIsAuthz_from_ejblitesecuredjsp
[INFO]      [exec] [javatest.batch] PASSED........com/sun/ts/tests/jacc/ejb/mr/Client.java#EjbNotAuthz_from_ejblitesecuredjsp
[INFO]      [exec] [javatest.batch] PASSED........com/sun/ts/tests/jacc/ejb/mr/Client.java#EjbSecRoleRef_from_ejblitesecuredjsp
[INFO]      [exec] [javatest.batch] PASSED........com/sun/ts/tests/jacc/ejb/mr/Client.java#excludeTest_from_ejblitesecuredjsp
[INFO]      [exec] [javatest.batch] PASSED........com/sun/ts/tests/jacc/ejb/mr/Client.java#InterMediateBean_CallerPrincipal_from_ejblitesecuredjsp
[INFO]      [exec] [javatest.batch] PASSED........com/sun/ts/tests/jacc/ejb/mr/Client.java#MGR_InRole_from_ejblitesecuredjsp
[INFO]      [exec] [javatest.batch] PASSED........com/sun/ts/tests/jacc/ejb/mr/Client.java#TargetBean_CallerPrincipal_from_ejblitesecuredjsp
[INFO]      [exec] [javatest.batch] PASSED........com/sun/ts/tests/jacc/ejb/mr/Client.java#uncheckedTest_from_ejblitesecuredjsp
```